### PR TITLE
Modified space detection in quoted strings for hiero2sparrow so it works with multiple spaces.

### DIFF
--- a/sparrow/util/hiero2sparrow/hiero2sparrow.rb
+++ b/sparrow/util/hiero2sparrow/hiero2sparrow.rb
@@ -48,7 +48,7 @@ puts "Parsing #{input_file_path} ..."
 IO.foreach(input_file_path) do |line|    
   
   # replace spaces within quotes
-  line.gsub!(/"(\S*)(\s+)(\S*")/) { |match| $1 + SPACE_MARKER + $3 }  
+  line.gsub!(/(["]).+?\1/) { |match| match.gsub(/\s+?/, SPACE_MARKER) }
 
   line_parts = line.split /\s+/    
   element_name = line_parts.shift  


### PR DESCRIPTION
Changed the regexp matching spaces within quoted values so that it deals with the case of multiple discontiguous spaces.

For example, the following string would not be matched because it has a space before and after the word "Bamba":

```
face="La Bamba LET"
```

The modified regexp matches the entire string between the quotes and then goes on to replace all the spaces in that substring with the SPACE_MARKER.

Spaces are every programmer's enemy :)
