### PR TITLE
Messed up init methods

### DIFF
--- a/sparrow/src/Classes/SPGLTexture.h
+++ b/sparrow/src/Classes/SPGLTexture.h
@@ -25,6 +25,7 @@ typedef enum
     SPTextureFormatPvrtcRGB4,
     SPTextureFormatPvrtcRGBA4,
     SPTextureFormat565,
+    SPTextureFormat888,
     SPTextureFormat5551,
     SPTextureFormat4444
 } SPTextureFormat;

--- a/sparrow/src/Classes/SPGLTexture.m
+++ b/sparrow/src/Classes/SPGLTexture.m
@@ -74,6 +74,10 @@
                 glTexFormat = GL_RGB;
                 glTexType = GL_UNSIGNED_SHORT_5_6_5;
                 break;
+            case SPTextureFormat888:
+                bitsPerPixel = 24;
+                glTexFormat = GL_RGB;
+                break;
             case SPTextureFormat5551:
                 bitsPerPixel = 16;                    
                 glTexFormat = GL_RGBA;

--- a/sparrow/src/Classes/SPMovieClip.h
+++ b/sparrow/src/Classes/SPMovieClip.h
@@ -112,6 +112,9 @@
 /// Pause playback.
 - (void)pause;
 
+/// Stop playback. Resets currentFrame to beginning.
+- (void)stop;
+
 /// ----------------
 /// @name Properties
 /// ----------------

--- a/sparrow/src/Classes/SPMovieClip.m
+++ b/sparrow/src/Classes/SPMovieClip.m
@@ -183,6 +183,12 @@
     mPlaying = NO;
 }
 
+- (void)stop
+{
+    mPlaying = NO;
+    self.currentFrame = 0;
+}
+
 - (void)updateCurrentFrame
 {
     self.texture = [mFrames objectAtIndex:mCurrentFrame];
@@ -204,6 +210,14 @@
         mCurrentTime += [[mFrameDurations objectAtIndex:i] doubleValue];
     
     [self updateCurrentFrame];
+}
+
+- (BOOL)isPlaying
+{
+    if (mPlaying)
+        return mLoop || mCurrentTime < mTotalDuration;
+    else
+        return NO;
 }
 
 - (void)checkIndex:(int)frameID

--- a/sparrow/src/Classes/SPTexture.m
+++ b/sparrow/src/Classes/SPTexture.m
@@ -212,6 +212,9 @@ enum PVRPixelType
         case OGL_RGB_565:
             properties.format = SPTextureFormat565;
             break;
+        case OGL_RGB_888:
+            properties.format = SPTextureFormat888;
+            break;
         case OGL_RGBA_5551:
             properties.format = SPTextureFormat5551;
             break;

--- a/sparrow/src/Classes/SPView.m
+++ b/sparrow/src/Classes/SPView.m
@@ -49,7 +49,7 @@
 
 - (id)initWithFrame:(CGRect)frame 
 {    
-    if ([super initWithFrame:frame]) 
+    if (self = [super initWithFrame:frame]) 
     {
         [self setup];
     }
@@ -58,7 +58,7 @@
 
 - (id)initWithCoder:(NSCoder *)decoder 
 {
-    if ([super initWithCoder:decoder]) 
+    if (self = [super initWithCoder:decoder]) 
     {
         [self setup];
     }

--- a/sparrow/src/UnitTests/SPMovieClipTest.m
+++ b/sparrow/src/UnitTests/SPMovieClipTest.m
@@ -152,11 +152,16 @@
     movie.loop = NO;
     [movie advanceTime:movie.duration + frameDuration];
     STAssertEquals(3, movie.currentFrame, @"movie looped");
+    STAssertFalse(movie.isPlaying, @"movie returned true for 'isPlaying' after reaching end");
     
     movie.currentFrame = 0;
     STAssertEquals(0, movie.currentFrame, @"wrong current frame");
     [movie advanceTime:frameDuration * 1.1];
     STAssertEquals(1, movie.currentFrame, @"wrong current frame");
+    
+    [movie stop];
+    STAssertFalse(movie.isPlaying, @"movie returned true for 'isPlaying' after reaching end");
+    STAssertEquals(0, movie.currentFrame, @"movie did not reset playhead on stop");
 }
 
 - (void)testChangeFps


### PR DESCRIPTION
How does SPView even work when it's init method uses `([super initWith....])` instead of `(self = [super init.....)`!?!?

Found while running my app through Build and Analyze (the sparrow files are added directly to my project so it scans them too).
