### PR TITLE
Another "how is this class event working?" situation with `[super init...

### DIFF
--- a/sparrow/src/Classes/SPMovieClip.m
+++ b/sparrow/src/Classes/SPMovieClip.m
@@ -54,13 +54,12 @@
 {
     if (textures.count == 0)
         [NSException raise:SP_EXC_INVALID_OPERATION format:@"empty texture array"];
-        
-    [self initWithFrame:[textures objectAtIndex:0] fps:fps];
-    
-    if (textures.count > 1)
-        for (int i=1; i<textures.count; ++i)
-            [self addFrame:[textures objectAtIndex:i]];
-    
+
+    if (self = [self initWithFrame:[textures objectAtIndex:0] fps:fps]){
+        if (textures.count > 1)
+            for (int i=1; i<textures.count; ++i)
+                [self addFrame:[textures objectAtIndex:i]];
+    }
     return self;
 }
 


### PR DESCRIPTION
Another "how is this class event working?" situation with `[super init...]` instead of `self = [super init];` init method.
This time it's SPMovieClip.
Don't worry that's all 'build & analyse' found so looks like that's the only typo's there are (in the init methods atleast).
