### PR TITLE
Fixed disable memory pooling when using LLVM compiler

### DIFF
--- a/sparrow/src/Classes/SPPoolObject.h
+++ b/sparrow/src/Classes/SPPoolObject.h
@@ -19,9 +19,6 @@ typedef struct
     SPPoolObject *lastElement;    
 } SPPoolInfo;
 
-#ifndef DISABLE_MEMORY_POOLING
-
-
 /** ------------------------------------------------------------------------------------------------
  
  The SPPoolObject class is an alternative to the base class `NSObject` that manages a pool of 
@@ -46,6 +43,8 @@ typedef struct
  
  ------------------------------------------------------------------------------------------------- */
 
+#ifndef DISABLE_MEMORY_POOLING
+
 @interface SPPoolObject : NSObject 
 {
     SPPoolObject *mPoolPredecessor;
@@ -61,10 +60,7 @@ typedef struct
 
 #else
 
-typedef NSObject SPPoolObject;
-
-/// Sparrow extensions for NSObject.
-@interface NSObject (SPPoolObjectExtensions)
+@interface SPPoolObject : NSObject 
 
 /// Dummy implementation of SPPoolObject method to simplify switching between NSObject and SPPoolObject.
 + (SPPoolInfo *)poolInfo;

--- a/sparrow/src/Classes/SPPoolObject.m
+++ b/sparrow/src/Classes/SPPoolObject.m
@@ -96,7 +96,7 @@
 
 #else
 
-@implementation NSObject (SPPoolObjectExtensions)
+@implementation SPPoolObject
 
 + (SPPoolInfo *)poolInfo 
 {

--- a/sparrow/src/Sparrow.xcodeproj/project.pbxproj
+++ b/sparrow/src/Sparrow.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0410;
+				LastUpgradeCheck = 0420;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "Sparrow" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -878,7 +878,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "UnitTests-Info.plist";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -899,7 +899,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "UnitTests-Info.plist";
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -920,7 +920,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Daniel Sperl";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = Sparrow;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "8F2B7F7C-97B8-4A99-B7EE-104D609292F6";
 			};
@@ -930,7 +930,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				PRODUCT_NAME = Sparrow;
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
 			};


### PR DESCRIPTION
Fixed SPPoolObject to work with LLVM compiler when DISABLE_MEMORY_POOLING is on.
Upgraded to LLVM compiler.
