### PR TITLE
Bypassing Bitmap font color setting

### DIFF
--- a/sparrow/src/Classes/SPBitmapFont.m
+++ b/sparrow/src/Classes/SPBitmapFont.m
@@ -206,8 +206,8 @@
             
             charImage.x = currentX + bitmapChar.xOffset;
             charImage.y = bitmapChar.yOffset;
-
-            charImage.color = color;
+            if(SP_COLOR_PART_ALPHA(color) != 0xFF)
+                charImage.color = color;
             [currentLine addChild:charImage];
             
             currentX += bitmapChar.xAdvance;


### PR DESCRIPTION
Hi there,

A while ago, I was trying to put in some bitmap fonts into a game and found that Sparrow was giving SP_BLACK as the default font color, basically masking/hiding/wiping out any useful color information that might be in the bitmaps.

I made a quick fix to get around this by using the "alpha" channel on an explicitly set color as a flag.  So a sparrow devs can now happily get text to show up in their full-color glory like so:

```
SPTextField* tf = [SPTextField textFieldWithWidth:100 height:30 text:@"hello world!"];
tf.color = 0xff000000;
// Work magic with colored text!
```

It'd probably be better to wrap the hard coded value in a preprocessor define like SP_DEFAULT_COLOR.

Hope this is useful to somebody.  =)
Jonathan
