### PR TITLE
Set AVAudioPlayer delegate to nil during SPAVSoundChannel dealloc

### DIFF
--- a/sparrow/src/Classes/SPAVSoundChannel.m
+++ b/sparrow/src/Classes/SPAVSoundChannel.m
@@ -41,6 +41,7 @@
 - (void)dealloc
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self];    
+    mPlayer.delegate = nil;
     [mPlayer release];
     [mSound release];
     [super dealloc];


### PR DESCRIPTION
I'm unable to reproduce this consistently, but even after stopping
the channel before releasing it, I find that sometimes the player
instance will stick around and try to send messages to its delegate,
resulting in bad access errors.

This change fixes the problem in my app. Unfortunately, as I don't
understand the underlying issue with AVAudioPlayer, I am having
trouble capturing this issue in a unit test or trivial demo.
