### PR TITLE
Make DISABLE_MEMORY_POOLING work with ARC

### DIFF
--- a/sparrow/src/Classes/SPMatrix.m
+++ b/sparrow/src/Classes/SPMatrix.m
@@ -154,6 +154,7 @@ static void setValues(SPMatrix *matrix, float a, float b, float c, float d, floa
                                                      tx:mTx ty:mTy];
 }
 
+#ifndef DISABLE_MEMORY_POOLING
 #pragma mark SPPoolObject
 
 + (SPPoolInfo *)poolInfo
@@ -161,5 +162,6 @@ static void setValues(SPMatrix *matrix, float a, float b, float c, float d, floa
     static SPPoolInfo poolInfo;
     return &poolInfo;
 }
+#endif
 
 @end

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -131,6 +131,7 @@
     return [[[self class] allocWithZone:zone] initWithX:mX y:mY];
 }
 
+#ifndef DISABLE_MEMORY_POOLING
 #pragma mark SPPoolObject
 
 + (SPPoolInfo *)poolInfo
@@ -138,5 +139,6 @@
     static SPPoolInfo poolInfo;
     return &poolInfo;
 }
+#endif
 
 @end

--- a/sparrow/src/Classes/SPPoolObject.h
+++ b/sparrow/src/Classes/SPPoolObject.h
@@ -13,12 +13,6 @@
 
 @class SPPoolObject;
 
-typedef struct
-{
-    Class poolClass;
-    SPPoolObject *lastElement;    
-} SPPoolInfo;
-
 /** ------------------------------------------------------------------------------------------------
  
  The SPPoolObject class is an alternative to the base class `NSObject` that manages a pool of 
@@ -45,6 +39,12 @@ typedef struct
 
 #ifndef DISABLE_MEMORY_POOLING
 
+typedef struct
+{
+    Class poolClass;
+    SPPoolObject *lastElement;
+} SPPoolInfo;
+
 @interface SPPoolObject : NSObject 
 {
   @private
@@ -62,10 +62,9 @@ typedef struct
 
 #else
 
-@interface SPPoolObject : NSObject 
+@class SPPoolInfo;
 
-/// Dummy implementation of SPPoolObject method to simplify switching between NSObject and SPPoolObject.
-+ (SPPoolInfo *)poolInfo;
+@interface SPPoolObject : NSObject
 
 /// Dummy implementation of SPPoolObject method to simplify switching between NSObject and SPPoolObject.
 + (int)purgePool;

--- a/sparrow/src/Classes/SPPoolObject.m
+++ b/sparrow/src/Classes/SPPoolObject.m
@@ -10,9 +10,10 @@
 //
 
 #import "SPPoolObject.h"
-#import <malloc/malloc.h>
 
 #ifndef DISABLE_MEMORY_POOLING
+
+#import <malloc/malloc.h>
 
 #define COMPLAIN_MISSING_IMP @"Class %@ needs this code:\n\
 + (SPPoolInfo *) poolInfo\n\
@@ -115,11 +116,6 @@
 #else
 
 @implementation SPPoolObject
-
-+ (SPPoolInfo *)poolInfo 
-{
-    return nil;
-}
 
 + (int)purgePool
 {

--- a/sparrow/src/Classes/SPRectangle.m
+++ b/sparrow/src/Classes/SPRectangle.m
@@ -132,6 +132,7 @@
     return [[[self class] allocWithZone:zone] initWithX:mX y:mY width:mWidth height:mHeight];
 }
 
+#ifndef DISABLE_MEMORY_POOLING
 #pragma mark SPPoolObject
 
 + (SPPoolInfo *)poolInfo
@@ -139,5 +140,6 @@
     static SPPoolInfo poolInfo;
     return &poolInfo;
 }
+#endif
 
 @end

--- a/sparrow/src/UnitTests/SPPoolObjectTest.m
+++ b/sparrow/src/UnitTests/SPPoolObjectTest.m
@@ -28,41 +28,46 @@
 
 - (void)testObjectPooling
 {
-    #ifndef DISABLE_MEMORY_POOLING
-    
     [SPPoint purgePool]; // clean existing pool
     
     SPPoint *p1 = [[SPPoint alloc] initWithX:1.0f y:2.0f];
     SPPoint *p2 = [[SPPoint alloc] initWithX:3.0f y:4.0f];
     SPPoint *p3 = [[SPPoint alloc] initWithX:5.0f y:6.0f];
     
-    // object should still exist after release
     [p3 release];
+#ifndef DISABLE_MEMORY_POOLING
+    // object should still exist after release
     STAssertEquals(5.0f, p3.x, @"object no longer accessible or wrong contents");
     STAssertEquals(6.0f, p3.y, @"object no longer accessible or wrong contents");
-    
+#endif
+
     SPPoint *p4 = [[SPPoint alloc] initWithX:15.0f y:16.0f];
-    
+#ifndef DISABLE_MEMORY_POOLING
     // p4 should be the recycled p3
     STAssertEquals((int)p3, (int)p4, @"object not taken from pool");
     STAssertEquals(15.0f, p3.x, @"object not taken from pool");
     STAssertEquals(16.0f, p3.y, @"object not taken from pool");
+#endif
 
     [p4 release];
     [p2 release];
     [p1 release];
     
     SPPoint *p5 = [[SPPoint alloc] initWithX:11.0f y:22.0f];
+#ifndef DISABLE_MEMORY_POOLING
     STAssertEquals((int)p5, (int)p1, @"object not taken from pool");
+#endif
     
-    int numPurgedPoints = [SPPoint purgePool];    
+    int numPurgedPoints = [SPPoint purgePool];
+#ifndef DISABLE_MEMORY_POOLING
     STAssertEquals(2, numPurgedPoints, @"wrong number of objects released on purge"); 
+#endif
     
     [p5 release];
     numPurgedPoints = [SPPoint purgePool];
+#ifndef DISABLE_MEMORY_POOLING
     STAssertEquals(1, numPurgedPoints, @"wrong number of objects released on purge"); 
-    
-    #endif
+#endif
 }
 
 @end


### PR DESCRIPTION
This moves the DISABLE_MEMORY_POOLING macro to hide SPPoolInfo completely when it's set. That gets projects using ARC and Sparrow working. purgePool is still visible and uses the previous noop implementation. 
