### PR TITLE
SPDisplayObject's self.stage should be deprecated

### DIFF
--- a/samples/demo/src/Classes/AnimationScene.m
+++ b/samples/demo/src/Classes/AnimationScene.m
@@ -106,7 +106,7 @@
     // animate the object. 
     // There is a default juggler at the stage, but you can create your own jugglers, as well.
     // That way, you can group animations into logical parts.    
-    [self.stage.juggler addObject:tween];
+    [[SPStage mainStage].juggler addObject:tween];
     
     // show which tweening function is used
     mTransitionLabel.text = transition;
@@ -114,7 +114,7 @@
     SPTween *hideTween = [SPTween tweenWithTarget:mTransitionLabel time:3.0f 
                                        transition:SP_TRANSITION_EASE_IN];
     [hideTween animateProperty:@"alpha" targetValue:0.0f];
-    [self.stage.juggler addObject:hideTween];
+    [[SPStage mainStage].juggler addObject:hideTween];
 }
 
 - (void)onTweenComplete:(SPEvent*)event
@@ -140,8 +140,8 @@
     // the method you would like to call on this proxy object instead of the real method target.
     // In this sample, [self colorizeEgg:] will be called after the specified delay.
     
-    [[self.stage.juggler delayInvocationAtTarget:self byTime:1.0f] colorizeEgg:YES];
-    [[self.stage.juggler delayInvocationAtTarget:self byTime:2.0f] colorizeEgg:NO];    
+    [[[SPStage mainStage].juggler delayInvocationAtTarget:self byTime:1.0f] colorizeEgg:YES];
+    [[[SPStage mainStage].juggler delayInvocationAtTarget:self byTime:2.0f] colorizeEgg:NO];    
 }
 
 - (void)colorizeEgg:(BOOL)colorize

--- a/samples/demo/src/Classes/BenchmarkScene.m
+++ b/samples/demo/src/Classes/BenchmarkScene.m
@@ -64,7 +64,7 @@
 
         if (mFrameCount % mWaitFrames == 0)
         {
-            float targetFPS = self.stage.frameRate;
+            float targetFPS = [SPStage mainStage].frameRate;
             float realFPS = mWaitFrames / mElapsed;
             
             if (ceilf(realFPS) >= targetFPS)
@@ -113,11 +113,11 @@
     [mJuggler removeAllObjects];
     
     NSLog(@"benchmark complete!");
-    NSLog(@"fps: %.1f", self.stage.frameRate);
+    NSLog(@"fps: %.1f", [SPStage mainStage].frameRate);
     NSLog(@"number of objects: %d", mContainer.numChildren);
     
     NSString *resultString = [NSString stringWithFormat:@"Result:\n%d objects\nwith %.0f fps", 
-                              mContainer.numChildren, self.stage.frameRate]; 
+                              mContainer.numChildren, [SPStage mainStage].frameRate]; 
     
     mResultText = [SPTextField textFieldWithWidth:250 height:200 text:resultString];
     mResultText.fontSize = 30;

--- a/samples/demo/src/Classes/Game.m
+++ b/samples/demo/src/Classes/Game.m
@@ -102,8 +102,8 @@
         SPTexture *backButtonTexture = [SPTexture textureWithContentsOfFile:@"button_back.png"];
         mBackButton = [[SPButton alloc] initWithUpState:backButtonTexture text:@"back"];
         mBackButton.visible = NO;
-        mBackButton.x = (int)(self.stage.width - mBackButton.width) / 2;
-        mBackButton.y = self.stage.height - mBackButton.height + 1;
+        mBackButton.x = (int)([SPStage mainStage].width - mBackButton.width) / 2;
+        mBackButton.y = [SPStage mainStage].height - mBackButton.height + 1;
         [mBackButton addEventListener:@selector(onBackButtonTriggered:) atObject:self 
                               forType:SP_EVENT_TYPE_TRIGGERED];
         [self addChild:mBackButton];

--- a/samples/demo/src/Classes/MovieScene.m
+++ b/samples/demo/src/Classes/MovieScene.m
@@ -52,12 +52,12 @@
 
 - (void)onAddedToStage:(SPEvent *)event
 {
-    [self.stage.juggler addObject:mMovie];
+    [[SPStage mainStage].juggler addObject:mMovie];
 }
 
 - (void)onRemovedFromStage:(SPEvent *)event
 {
-    [self.stage.juggler removeObject:mMovie];
+    [[SPStage mainStage].juggler removeObject:mMovie];
 }
 
 @end

--- a/sparrow/src/Classes/SPButton.m
+++ b/sparrow/src/Classes/SPButton.m
@@ -99,7 +99,7 @@
     else if (touch.phase == SPTouchPhaseMoved && mIsDown)
     {
         // reset button when user dragged too far away after pushing
-        SPRectangle *buttonRect = [self boundsInSpace:self.stage];
+        SPRectangle *buttonRect = [self boundsInSpace:[SPStage mainStage]];
         if (touch.globalX < buttonRect.x - MAX_DRAG_DIST ||
             touch.globalY < buttonRect.y - MAX_DRAG_DIST ||
             touch.globalX > buttonRect.x + buttonRect.width + MAX_DRAG_DIST ||

--- a/sparrow/src/Classes/SPDisplayObject.h
+++ b/sparrow/src/Classes/SPDisplayObject.h
@@ -169,7 +169,8 @@
 @property (nonatomic, readonly) SPDisplayObject *root;
 
 /// The stage the display object is connected to, or nil if it is not connected to a stage.
-@property (nonatomic, readonly) SPStage *stage;
+/// DEPRECATED! Use `[SPStage mainStage]` instead.
+@property (nonatomic, readonly) SPStage *stage __attribute__((deprecated));
 
 /// The transformation matrix of the object relative to its parent.
 @property (nonatomic, readonly) SPMatrix *transformationMatrix;

--- a/sparrow/src/Classes/SPDisplayObject.m
+++ b/sparrow/src/Classes/SPDisplayObject.m
@@ -283,9 +283,7 @@
 
 - (SPStage*)stage
 {
-    SPDisplayObject *root = self.root;
-    if ([root isKindOfClass:[SPStage class]]) return (SPStage*) root;
-    else return nil;
+    return [SPStage mainStage];
 }
 
 - (SPMatrix*)transformationMatrix

--- a/sparrow/src/Classes/SPDisplayObjectContainer.m
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.m
@@ -13,6 +13,7 @@
 #import "SPEnterFrameEvent.h"
 #import "SPDisplayObject_Internal.h"
 #import "SPMacros.h"
+#import "SPStage.h"
 
 // --- C functions ---------------------------------------------------------------------------------
 
@@ -71,7 +72,7 @@ static void getChildEventListeners(SPDisplayObject *object, NSString *eventType,
         [child dispatchEvent:addedEvent];
         [addedEvent release];    
         
-        if (self.stage)
+        if ([SPStage mainStage])
         {
             SPEvent *addedToStageEvent = [[SPEvent alloc] initWithType:SP_EVENT_TYPE_ADDED_TO_STAGE];
             [child dispatchEventOnChildren:addedToStageEvent];
@@ -139,7 +140,7 @@ static void getChildEventListeners(SPDisplayObject *object, NSString *eventType,
         [child dispatchEvent:remEvent];
         [remEvent release];    
         
-        if (self.stage)
+        if ([SPStage mainStage])
         {
             SPEvent *remFromStageEvent = [[SPEvent alloc] initWithType:SP_EVENT_TYPE_REMOVED_FROM_STAGE];
             [child dispatchEventOnChildren:remFromStageEvent];

--- a/sparrow/src/Classes/SPJuggler.h
+++ b/sparrow/src/Classes/SPJuggler.h
@@ -23,7 +23,7 @@
  
  There is a default juggler in every stage. You can access it by calling
  
-	SPJuggler *juggler = self.stage.juggler;
+	SPJuggler *juggler = [SPStage mainStage].juggler;
  
  in any object that has access to the stage. You can, however, create juggler objects yourself, too.
  That way, you can group your game into logical components that handle their animations independently.

--- a/sparrow/src/Classes/SPStage.h
+++ b/sparrow/src/Classes/SPStage.h
@@ -29,16 +29,7 @@
  A stage also contains a default juggler which you can use for your animations. It is advanced 
  automatically once per frame. You can access this juggler from any display object by calling
  
-	self.stage.juggler
- 
- You have to take care, however, that the display object you are making this call from is already
- connected to the stage - otherwise, the method will return `nil`, and you won't have access to 
- the juggler.
- 
- As an alternative, you can also use this static method to access your stage. It will return the
- first stage instance that was created (and normally, there is only one stage available, anyway).
- 
-    [SPStage mainStage];
+	[SPStage mainStage].juggler
  
 ------------------------------------------------------------------------------------------------- */
 

--- a/sparrow/src/Classes/SPTouchProcessor.m
+++ b/sparrow/src/Classes/SPTouchProcessor.m
@@ -17,6 +17,7 @@
 #import "SPPoint.h"
 #import "SPMatrix.h"
 #import "SPDisplayObjectContainer.h"
+#import "SPStage.h"
 
 #define MULTITAP_TIME 0.25f
 #define MULTITAP_DIST 25
@@ -70,7 +71,7 @@
                 existingTouch.phase = touch.phase;
                 existingTouch.tapCount = touch.tapCount;
                 
-                if (!existingTouch.target.stage)
+                if (![[SPStage mainStage] containsChild:existingTouch.target])
                 {
                     // target could have been removed from stage -> find new target in that case
                     SPPoint *touchPosition = [SPPoint pointWithX:touch.globalX y:touch.globalY];

--- a/sparrow/src/Classes/SPTween.h
+++ b/sparrow/src/Classes/SPTween.h
@@ -41,7 +41,7 @@ typedef enum
 	[tween animateProperty:@"x" targetValue:object.x + 50];
  	[tween animateProperty:@"rotation" targetValue:object.rotation + SP_D2R(45)];
  	[tween animateProperty:@"alpha" targetValue:0.0f];
- 	[self.stage.juggler addObject:tween];
+ 	[[SPStage mainStage].juggler addObject:tween];
  
  Note that the object is added to a juggler at the end. A tween will only be executed if its
  `advanceTime:` method is executed regularly - the juggler will do that for us, and will release


### PR DESCRIPTION
This property is a major cause for confusion and [SPStage mainStage] should always
be used instead. I have seen at least 9 threads about this in the Sparrow Forum, because people are confused about which method should be used to access the stage. I have also updated the documentation to remove references to self.stage.

http://forum.sparrow-framework.org/topic/animation-in-playc-file#post-11012
http://forum.sparrow-framework.org/topic/name-property-issue#post-8221
http://forum.sparrow-framework.org/topic/issues-with-tweenning-and-the-juggler#post-10533
http://forum.sparrow-framework.org/topic/spmovieclip-not-animated-even-after-a-self#post-6995
http://forum.sparrow-framework.org/topic/no-spjuggler#post-9705
http://forum.sparrow-framework.org/topic/movieclip-doesnt-play#post-10475
http://forum.sparrow-framework.org/topic/problem-with-tweens-in-substage-tweens-do-not-start#post-7962
http://forum.sparrow-framework.org/topic/spmovieclip-not-playing#post-11507
http://forum.sparrow-framework.org/topic/sptween-nao-funciona-na-classe-spsprite#post-10226

Thanks for your time,
Brian
