### PR TITLE
Add a method to use a new shared EAGLContext

### DIFF
--- a/sparrow/src/Classes/SPView.h
+++ b/sparrow/src/Classes/SPView.h
@@ -75,4 +75,7 @@
 /// Stops rendering and event handling. Call this when the application moves into the background.
 - (void)stop;
 
+/// Sets the current thread's EAGLContext to a new context that uses the main context's sharegroup. Call this when loading textures from a background thread. Returns YES if the new context was successfully set.
+- (BOOL)useNewSharedEAGLContext;
+
 @end

--- a/sparrow/src/Classes/SPView.m
+++ b/sparrow/src/Classes/SPView.m
@@ -235,6 +235,20 @@
     }
 }
 
+- (BOOL)useNewSharedEAGLContext {
+    EAGLContext *threadContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES1 sharegroup:mContext.sharegroup];
+    if (!threadContext) {
+        NSLog(@"Unable to create shared EAGLContext!");
+        return NO;
+    }
+    [threadContext autorelease];
+    if (![EAGLContext setCurrentContext:threadContext]) {
+        NSLog(@"Unable to set EAGLContext to new shared context!");
+        return NO;
+    }
+    return YES;
+}
+
 + (Class)layerClass 
 {
     return [CAEAGLLayer class];


### PR DESCRIPTION
I pulled the code from http://forum.sparrow-framework.org/topic/thread-safety-when-rendering-spimages#post-9344 into useNewSharedEAGLContext on SPView. It creates a new EAGLContext with the main context's sharegroup. It then makes it the context for the current thread.

This is part of issue #1019.
