### PR TITLE
Add convenience methods to SPPoint and SPRectangle

### DIFF
--- a/sparrow/src/Classes/SPPoint.h
+++ b/sparrow/src/Classes/SPPoint.h
@@ -44,6 +44,9 @@
 /// @name Methods
 // --------------
 
+/// Returns the negation of this point
+- (SPPoint *)negate;
+
 /// Adds a point to the current point and returns the resulting point.
 - (SPPoint *)addPoint:(SPPoint *)point;
 
@@ -53,8 +56,17 @@
 /// Scales the point by a certain factor and returns the resulting point.
 - (SPPoint *)scaleBy:(float)scalar;
 
+/// Rotates the point by the given angle (in radians) and returns the resulting point.
+- (SPPoint *)rotateBy:(float)angle;
+
 /// Scales the line segment between the origin and the current point to one.
 - (SPPoint *)normalize;
+
+/// Returns the dot-product of this vector and the given vector
+- (float)dot:(SPPoint *)other;
+
+/// Returns the angle between this vector and the given vector
+- (float)angleBetween:(SPPoint *)other;
 
 /// Compares two points.
 - (BOOL)isEqual:(id)other;
@@ -73,10 +85,16 @@
 @property (nonatomic, assign) float x;
 @property (nonatomic, assign) float y;
 
+/// The squared distance to the origin (or the squared length of the vector)
+@property (readonly) float lengthSq;
+
 /// The distance to the origin (or the length of the vector).
 @property (readonly) float length;
 
 /// The angle between the origin and the point (in RAD).
 @property (readonly) float angle;
+
+/// Returns true if this is the zero-vector
+@property (readonly) BOOL isZero;
 
 @end

--- a/sparrow/src/Classes/SPPoint.h
+++ b/sparrow/src/Classes/SPPoint.h
@@ -80,6 +80,9 @@
 /// Calculates the distance between two points.
 + (float)distanceFromPoint:(SPPoint *)p1 toPoint:(SPPoint *)p2;
 
+/// Calculates the squared distance between two points.
++ (float)distanceSqFromPoint:(SPPoint *)p1 toPoint:(SPPoint *)p2;
+
 /// Determines a point between two specified points. `ratio = 0 -> p1, ratio = 1 -> p2`
 + (SPPoint *)interpolateFromPoint:(SPPoint *)p1 toPoint:(SPPoint *)p2 ratio:(float)ratio;
 

--- a/sparrow/src/Classes/SPPoint.h
+++ b/sparrow/src/Classes/SPPoint.h
@@ -50,8 +50,14 @@
 /// Adds a point to the current point and returns the resulting point.
 - (SPPoint *)addPoint:(SPPoint *)point;
 
+/// Adds a point to the current point and returns the resulting point.
+- (SPPoint *)addX:(float)x y:(float)y;
+
 /// Substracts a point from the current point and returns the resulting point.
 - (SPPoint *)subtractPoint:(SPPoint *)point;
+
+/// Substracts a point from the current point and returns the resulting point.
+- (SPPoint *)subtractX:(float)x y:(float)y;
 
 /// Scales the point by a certain factor and returns the resulting point.
 - (SPPoint *)scaleBy:(float)scalar;

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -43,6 +43,11 @@
     return [self initWithX:0.0f y:0.0f];
 }
 
+- (float)lengthSq 
+{
+    return SQ(mX) + SQ(mY);
+}
+
 - (float)length
 {
     return sqrtf(SQ(mX) + SQ(mY));
@@ -51,6 +56,17 @@
 - (float)angle
 {
     return atan2f(mY, mX);
+}
+
+- (BOOL)isZero
+{
+    return mX == 0 && mY == 0;
+}
+
+- (SPPoint *)negate
+{
+    SPPoint *result = [[SPPoint alloc] initWithX:-mX y:-mY];
+    return [result autorelease];
 }
 
 - (SPPoint*)addPoint:(SPPoint*)point
@@ -71,7 +87,15 @@
     return [result autorelease];
 }
 
-- (SPPoint*)normalize
+- (SPPoint *)rotateBy:(float)angle
+{
+    float sina = sinf(angle);
+    float cosa = cosf(angle);
+    SPPoint *result = [[SPPoint alloc] initWithX:(mX * cosa) - (mY * sina) y:(mX * sina) + (mY * cosa)];
+    return [result autorelease];
+}
+
+- (SPPoint *)normalize
 {
     if (mX == 0 && mY == 0)
         [NSException raise:SP_EXC_INVALID_OPERATION format:@"Cannot normalize point in the origin"];
@@ -79,6 +103,17 @@
     float inverseLength = 1.0f / self.length;
     SPPoint *result = [[SPPoint alloc] initWithX:mX * inverseLength y:mY * inverseLength];
     return [result autorelease];
+}
+
+- (float)dot:(SPPoint *)other
+{
+    return mX * other->mX + mY * other->mY;
+}
+
+- (float)angleBetween:(SPPoint *)other 
+{
+    float cos = [self dot:other] / (self.length * other.length);
+    return cos >= 1.0f ? 0.0f : acosf(cos);
 }
 
 - (BOOL)isEqual:(id)other 

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -144,7 +144,12 @@
 
 + (float)distanceFromPoint:(SPPoint*)p1 toPoint:(SPPoint*)p2
 {
-    return sqrtf(SQ(p2->mX - p1->mX) + SQ(p2->mY - p1->mY));
+    return sqrtf([SPPoint distanceSqFromPoint:p1 toPoint:p2]);
+}
+
++ (float)distanceSqFromPoint:(SPPoint *)p1 toPoint:(SPPoint *)p2
+{
+    return SQ(p2->mX - p1->mX) + SQ(p2->mY - p1->mY);
 }
 
 + (SPPoint *)interpolateFromPoint:(SPPoint *)p1 toPoint:(SPPoint *)p2 ratio:(float)ratio

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -71,13 +71,23 @@
 
 - (SPPoint*)addPoint:(SPPoint*)point
 {
-    SPPoint *result = [[SPPoint alloc] initWithX:mX+point->mX y:mY+point->mY];    
+    return [self addX:point->mX y:point->mY];
+}
+
+- (SPPoint *)addX:(float)x y:(float)y
+{
+    SPPoint *result = [[SPPoint alloc] initWithX:mX+x y:mY+y];    
     return [result autorelease];
 }
 
 - (SPPoint*)subtractPoint:(SPPoint*)point
 {
-    SPPoint *result = [[SPPoint alloc] initWithX:mX-point->mX y:mY-point->mY];    
+    return [self subtractX:point->mX y:point->mY];
+}
+
+- (SPPoint *)subtractX:(float)x y:(float)y
+{
+    SPPoint *result = [[SPPoint alloc] initWithX:mX-x y:mY-y];    
     return [result autorelease];
 }
 

--- a/sparrow/src/Classes/SPRectangle.h
+++ b/sparrow/src/Classes/SPRectangle.h
@@ -61,6 +61,15 @@
 /// Sets width and height components to zero.
 - (void)setEmpty;
 
+/// Sets the bounds of the rectangle.
+- (void)setX:(float)x y:(float)y width:(float)width height:(float)height;
+
+/// Expands the bounds of this rectangle to contain the specified point.
+- (void)addX:(float)x y:(float)y;
+
+/// Expands the bounds of this rectangle to contain the specified point.
+- (void)addPoint:(SPPoint *)p;
+
 /// ----------------
 /// @name Properties
 /// ----------------
@@ -70,6 +79,16 @@
 @property (nonatomic, assign) float y;
 @property (nonatomic, assign) float width;
 @property (nonatomic, assign) float height;
+
+@property (nonatomic, readonly) float minX;
+@property (nonatomic, readonly) float minY;
+@property (nonatomic, readonly) float maxX;
+@property (nonatomic, readonly) float maxY;
+@property (nonatomic, readonly) float centerX;
+@property (nonatomic, readonly) float centerY;
+@property (nonatomic, readonly) SPPoint *min;
+@property (nonatomic, readonly) SPPoint *max;
+@property (nonatomic, readonly) SPPoint *center;
 
 /// Determines if a rectangle has an empty area.
 @property (nonatomic, readonly) BOOL isEmpty;

--- a/sparrow/src/Classes/SPRectangle.m
+++ b/sparrow/src/Classes/SPRectangle.m
@@ -98,6 +98,73 @@
     mX = mY = mWidth = mHeight = 0;
 }
 
+- (void)setX:(float)x y:(float)y width:(float)width height:(float)height 
+{
+    mX = x;
+    mY = y;
+    mWidth = width;
+    mHeight = height;
+}
+
+- (void)addX:(float)x y:(float)y 
+{
+    float x1 = MIN(mX, x);
+    float x2 = MAX(mX + mWidth, x);
+    float y1 = MIN(mY, y);
+    float y2 = MAX(mY + mHeight, y);
+    [self setX:x1 y:y1 width:x2 - x1 height:y2 - y1];
+}
+
+- (void)addPoint:(SPPoint *)p 
+{
+    [self addX:p.x y:p.y];
+}
+
+- (float)minX 
+{
+    return mX;
+}
+
+- (float)minY
+{
+    return mY;
+}
+
+- (float)maxX
+{
+    return mX + mWidth;
+}
+
+- (float)maxY
+{
+    return mY + mHeight;
+}
+
+- (float)centerX
+{
+    return mX + (mWidth / 2.0f);
+}
+
+- (float)centerY
+{
+    return mY + (mHeight / 2.0f);
+}
+
+- (SPPoint *)min
+{
+    return [[[SPPoint alloc] initWithX:self.minX y:self.minY] autorelease];
+}
+
+- (SPPoint *)max
+{
+    return [[[SPPoint alloc] initWithX:self.maxX y:self.maxY] autorelease];
+}
+
+- (SPPoint *)center
+{
+    return [[[SPPoint alloc] initWithX:self.centerX y:self.centerY] autorelease];
+}
+
 - (BOOL)isEmpty
 {
     return mWidth == 0 || mHeight == 0;


### PR DESCRIPTION
This change adds a handful of convenient vector operations to SPPoint:
- negate
- rotateBy
- dot
- angleBetween
- lengthSq
- isZero

And some utility functions for SPRectangle:
- setX:y:width:height
- addX:y
- addPoint:
- minX, minY, maxX, maxY, centerX, centerY, min, max, center
