### PR TITLE
allow getting/setting location, pivot, and scale with SPPoint

### DIFF
--- a/sparrow/src/Classes/SPDisplayObject.h
+++ b/sparrow/src/Classes/SPDisplayObject.h
@@ -129,17 +129,26 @@
 /// The y coordinate of the object relative to the local coordinates of the parent.
 @property (nonatomic, assign) float y;
 
+/// The coordinates of the object relative to the local coordinates of the parent
+@property (nonatomic, copy) SPPoint *loc;
+
 /// The x coordinate of the object's origin in its own coordinate space (default: 0).
 @property (nonatomic, assign) float pivotX;
 
 /// The y coordinate of the object's origin in its own coordinate space (default: 0).
 @property (nonatomic, assign) float pivotY;
 
+/// The object's origin in its own coordinate space
+@property (nonatomic, copy) SPPoint *pivot;
+
 /// The horizontal scale factor. "1" means no scale, negative values flip the object.
 @property (nonatomic, assign) float scaleX;
 
 /// The vertical scale factor. "1" means no scale, negative values flip the object.
 @property (nonatomic, assign) float scaleY;
+
+/// The object's x and y scale factor
+@property (nonatomic, copy) SPPoint *scale;
 
 /// The width of the object in points.
 @property (nonatomic, assign) float width;

--- a/sparrow/src/Classes/SPDisplayObject.m
+++ b/sparrow/src/Classes/SPDisplayObject.m
@@ -231,6 +231,39 @@
     [super dispatchEvent:event];
 }
 
+- (SPPoint *)loc
+{
+    return [SPPoint pointWithX:self.x y:self.y];
+}
+
+- (void)setLoc:(SPPoint *)loc
+{
+    self.x = loc.x;
+    self.y = loc.y;
+}
+
+- (SPPoint *)pivot
+{
+    return [SPPoint pointWithX:self.pivotX y:self.pivotY];
+}
+
+- (void)setPivot:(SPPoint *)pivot
+{
+    self.pivotX = pivot.x;
+    self.pivotY = pivot.y;
+}
+
+- (SPPoint *)scale
+{
+    return [SPPoint pointWithX:self.scaleX y:self.scaleY];
+}
+
+- (void)setScale:(SPPoint *)scale
+{
+    self.scaleX = scale.x;
+    self.scaleY = scale.y;
+}
+
 - (float)width
 {
     return [self boundsInSpace:mParent].width; 


### PR DESCRIPTION
I find myself frequently doing things like:

myDisplayObj.x = loc.x;
myDisplayObj.y = loc.y;

which becomes a one-liner with this change:

myDisplayObj.loc = loc;
