### PR TITLE
SPDisplayObjectContainer.sortChildren

### DIFF
--- a/sparrow/src/Classes/SPDisplayObjectContainer.h
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.h
@@ -89,6 +89,9 @@
 /// Swaps the indexes of two children.
 - (void)swapChildAtIndex:(int)index1 withChildAtIndex:(int)index2;
 
+/// Sorts the display children using the given NSComparator block.
+- (void)sortChildren:(NSComparator)comp;
+
 /// ----------------
 /// @name Properties
 /// ----------------

--- a/sparrow/src/Classes/SPDisplayObjectContainer.h
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.h
@@ -90,6 +90,14 @@
 - (void)swapChildAtIndex:(int)index1 withChildAtIndex:(int)index2;
 
 /// Sorts the display children using the given NSComparator block.
+/// For example, to depth-sort children such that objects lower on the screen are
+/// sorted in front of those higher on the screen:
+///
+/// [container sortChildren:^(id a, id b) {
+///     float aY = ((SPDisplayObject *) a).y;
+///     float bY = ((SPDisplayObject *)b).y;
+///     return (aY < bY ? NSOrderedAscending : (aY > bY ? NSOrderedDescending : NSOrderedSame));
+/// }];
 - (void)sortChildren:(NSComparator)comp;
 
 /// ----------------

--- a/sparrow/src/Classes/SPDisplayObjectContainer.m
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.m
@@ -169,6 +169,11 @@ static void getChildEventListeners(SPDisplayObject *object, NSString *eventType,
     [mChildren exchangeObjectAtIndex:index1 withObjectAtIndex:index2];
 }
 
+- (void)sortChildren:(NSComparator)comp
+{
+    [mChildren sortWithOptions:NSSortStable usingComparator:comp];
+}
+
 - (void)removeAllChildren
 {
     for (int i=mChildren.count-1; i>=0; --i)


### PR DESCRIPTION
a method for sorting a DisplayObjectContainer's children (just trivially calls through to NSMutableArray.sortWithOptions:)
