### PR TITLE
Provide hash functions for SPPoint, SPRectangle, and SPMatrix.

### DIFF
--- a/sparrow/src/Classes/SPMatrix.m
+++ b/sparrow/src/Classes/SPMatrix.m
@@ -130,6 +130,12 @@ static void setValues(SPMatrix *matrix, float a, float b, float c, float d, floa
     }
 }
 
+- (NSUInteger)hash
+{
+    // Equality is not transitive in SPMatrix, so we can't compute a good hash function.
+    return 0;
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"(a=%f, b=%f, c=%f, d=%f, tx=%f, ty=%f)", 

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -121,6 +121,12 @@
     }
 }
 
+- (NSUInteger)hash
+{
+    // Equality is not transitive in SPPoint, so we can't compute a good hash function.
+    return 0;
+}
+
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"(x=%f, y=%f)", mX, mY];

--- a/sparrow/src/Classes/SPRectangle.m
+++ b/sparrow/src/Classes/SPRectangle.m
@@ -144,6 +144,12 @@
     }
 }
 
+- (NSUInteger)hash
+{
+    // Equality is not transitive in SPRectangle, so we can't compute a good hash function.
+    return 0;
+}
+
 - (NSString*)description
 {
     return [NSString stringWithFormat:@"(x: %f, y: %f, width: %f, height: %f)", mX, mY, mWidth, mHeight];


### PR DESCRIPTION
Since equality is not transitive in these float-based classes, we can't
compute a good hash function - but a poor hash is better than the default,
which breaks the "if isEqual(a,b) then hash(a) == hash(b)" contract.

(Without hash functions, if you (inadvisably) try to use any of these classes as keys in containers, the behavior is undefined.)
