### PR TITLE
add SPTouch.touchId

### DIFF
--- a/sparrow/src/Classes/SPTouch.h
+++ b/sparrow/src/Classes/SPTouch.h
@@ -55,6 +55,7 @@ typedef enum
 {
   @private
     double mTimestamp;
+    int mTouchId;
     float mGlobalX;
     float mGlobalY;
     float mPreviousGlobalX;
@@ -80,6 +81,9 @@ typedef enum
 
 /// The moment the event occurred (in seconds since application start).
 @property (nonatomic, readonly) double timestamp;
+
+/// The touch's unique ID
+@property (nonatomic, readonly) int touchId;
 
 /// The x-position of the touch in screen coordinates
 @property (nonatomic, readonly) float globalX;

--- a/sparrow/src/Classes/SPTouch.m
+++ b/sparrow/src/Classes/SPTouch.m
@@ -17,6 +17,7 @@
 @implementation SPTouch
 
 @synthesize timestamp = mTimestamp;
+@synthesize touchId = mTouchId;
 @synthesize globalX = mGlobalX;
 @synthesize globalY = mGlobalY;
 @synthesize previousGlobalX = mPreviousGlobalX;
@@ -59,6 +60,11 @@
 - (void)setTimestamp:(double)timestamp
 {
     mTimestamp = timestamp;
+}
+
+- (void)setTouchId:(int)touchId
+{
+    mTouchId = touchId;
 }
 
 - (void)setGlobalX:(float)x

--- a/sparrow/src/Classes/SPTouchProcessor.h
+++ b/sparrow/src/Classes/SPTouchProcessor.h
@@ -26,6 +26,7 @@
   @private
     SPDisplayObjectContainer *mRoot;
     NSMutableSet *mCurrentTouches;
+    int mTouchIdCounter;
 }
 
 /// ------------------

--- a/sparrow/src/Classes/SPTouchProcessor.m
+++ b/sparrow/src/Classes/SPTouchProcessor.m
@@ -87,6 +87,7 @@
             // new touch!
             currentTouch = [SPTouch touch];
             currentTouch.timestamp = touch.timestamp;
+            currentTouch.touchId = mTouchIdCounter++;
             currentTouch.globalX = touch.globalX;
             currentTouch.globalY = touch.globalY;
             currentTouch.previousGlobalX = touch.previousGlobalX;

--- a/sparrow/src/Classes/SPTouch_Internal.h
+++ b/sparrow/src/Classes/SPTouch_Internal.h
@@ -15,6 +15,7 @@
 @interface SPTouch (Internal)
 
 - (void)setTimestamp:(double)timestamp;
+- (void)setTouchId:(int)touchId;
 - (void)setGlobalX:(float)x;
 - (void)setGlobalY:(float)y;
 - (void)setPreviousGlobalX:(float)x;


### PR DESCRIPTION
Each SPTouch has a unique ID that remains consistent through all touch phases,
which makes it much easier to keep track of multiple simultaneous touches

(I went with "touchId" instead of "id" because of id's status as a reserved keyword in ObjC)
