### PR TITLE
Text autosize

### DIFF
--- a/sparrow/src/Classes/SPBitmapFont.h
+++ b/sparrow/src/Classes/SPBitmapFont.h
@@ -77,9 +77,12 @@
 - (SPBitmapChar *)charByID:(int)charID;
 
 /// Creates a display object that contains the given text by arranging individual chars.
-- (SPDisplayObject *)createDisplayObjectWithWidth:(float)width height:(float)height
+- (SPDisplayObject *)createDisplayObjectWithWidth:(float)width height:(float)height 
                                              text:(NSString *)text fontSize:(float)size color:(uint)color 
                                            hAlign:(SPHAlign)hAlign vAlign:(SPVAlign)vAlign
+                                         autoSize:(SPAutoSize)autoSize 
+                                 autoSizeMaxWidth:(float)autoSizeMaxWidth
+                                autoSizeMaxHeight:(float)autoSizeMaxHeight
                                            border:(BOOL)border kerning:(BOOL)kerning;
 
 /// ----------------
@@ -93,6 +96,6 @@
 @property (nonatomic, readonly) float size;
 
 /// The height of one line in pixels.
-@property (nonatomic, assign)   float lineHeight;
+@property (nonatomic, assign) float lineHeight;
 
 @end

--- a/sparrow/src/Classes/SPBitmapFont.m
+++ b/sparrow/src/Classes/SPBitmapFont.m
@@ -219,7 +219,6 @@
     int lastWhiteSpace = -1;
     int lastCharID = -1;
     float currentX = 0;
-    int currentLineStartIdx = 0;
     
     float totalWidth = 0;
     float totalHeight = 0;
@@ -295,7 +294,6 @@
                 currentLine.y = totalHeight;
                 
                 currentX = 0;
-                currentLineStartIdx = i + 1;
                 lastWhiteSpace = -1;
                 lastCharID = -1;
             }

--- a/sparrow/src/Classes/SPBitmapFont.m
+++ b/sparrow/src/Classes/SPBitmapFont.m
@@ -26,10 +26,17 @@
 #define CHAR_TAB      9
 #define CHAR_NEWLINE 10
 
+#define GET_CHAR(charID) ({ \
+    SPBitmapChar *theChar = [self charByID:charID]; \
+    if (theChar == nil) theChar = [self charByID:CHAR_SPACE]; \
+    theChar; \
+})
+
 // --- private interface ---------------------------------------------------------------------------
 
 @interface SPBitmapFont ()
 
++ (float)getLineWidth:(SPSprite *)line;
 - (void)parseFontXml:(NSString*)path;
 
 @end
@@ -165,134 +172,185 @@
     return (SPBitmapChar *)[mChars objectForKey:[NSNumber numberWithInt:charID]];
 }
 
-- (SPDisplayObject *)createDisplayObjectWithWidth:(float)width height:(float)height
++ (float)getLineWidth:(SPSprite *)line
+{
+    float lineWidth = 0;
+    if (line.numChildren != 0)
+    {
+        SPDisplayObject *lastChar = [line childAtIndex:line.numChildren-1];
+        lineWidth = lastChar.x + lastChar.width;
+    }
+    return lineWidth;
+}
+
+- (SPDisplayObject *)createDisplayObjectWithWidth:(float)width height:(float)height 
                                              text:(NSString *)text fontSize:(float)size color:(uint)color 
-                                           hAlign:(SPHAlign)hAlign vAlign:(SPVAlign)vAlign
+                                           hAlign:(SPHAlign)hAlign vAlign:(SPVAlign)vAlign 
+                                         autoSize:(SPAutoSize)autoSize 
+                                 autoSizeMaxWidth:(float)autoSizeMaxWidth 
+                                autoSizeMaxHeight:(float)autoSizeMaxHeight 
                                            border:(BOOL)border kerning:(BOOL)kerning
-{    
-    SPSprite *lineContainer = [SPSprite sprite];
+{
+    if (size == SP_NATIVE_FONT_SIZE) size = mSize;
     
-    if (size == SP_NATIVE_FONT_SIZE) size = mSize;    
-    float scale = size / mSize;    
-    lineContainer.scaleX = lineContainer.scaleY = scale;        
-    float containerWidth = width / scale;
-    float containerHeight = height / scale;    
+    float scale = size / mSize;
+    float maxWidth = 0;
+    float maxHeight = 0;
+    switch (autoSize) 
+    {
+        case SPAutoSizeNone:
+            maxWidth = width / scale;
+            maxHeight = height / scale;
+            break;
+            
+        case SPAutoSizeSingleLine:
+            maxWidth = (autoSizeMaxWidth > 0 ? autoSizeMaxWidth / scale : FLT_MAX);
+            maxHeight = mLineHeight;
+            break;
+            
+        case SPAutoSizeMultiline:
+            maxWidth = (autoSizeMaxWidth > 0 ? autoSizeMaxWidth / scale : FLT_MAX);
+            maxHeight = (autoSizeMaxHeight > 0 ? autoSizeMaxHeight / scale : FLT_MAX);
+            break;
+    }
+    
+    BOOL multiline = (autoSize != SPAutoSizeSingleLine);
     
     int lastWhiteSpace = -1;
     int lastCharID = -1;
     float currentX = 0;
+    int currentLineStartIdx = 0;
+    
+    float totalWidth = 0;
+    float totalHeight = 0;
+    
+    SPSprite *lineContainer = [SPSprite sprite];
+    lineContainer.scaleX = lineContainer.scaleY = scale;
     SPSprite *currentLine = [SPSprite sprite];
     
-    for (int i=0; i<text.length; i++)
-    {        
+    for (int i = 0; i < text.length; ++i) 
+    {
         BOOL lineFull = NO;
-
+        
         int charID = [text characterAtIndex:i];    
-        if (charID == CHAR_NEWLINE)        
+        if (multiline && charID == CHAR_NEWLINE) 
         {
             lineFull = YES;
-        }            
+        } 
         else 
-        {        
-            if (charID == CHAR_SPACE || charID == CHAR_TAB)        
-                lastWhiteSpace = i;        
+        {
+            if (!multiline && charID == CHAR_NEWLINE) 
+                charID = CHAR_SPACE;
+            if (charID == CHAR_SPACE || charID == CHAR_TAB) 
+                lastWhiteSpace = i;
             
-            SPBitmapChar *bitmapChar = [self charByID:charID];
-            if (!bitmapChar) bitmapChar = [self charByID:CHAR_SPACE];
-            SPImage *charImage = [bitmapChar createImage];
+            SPBitmapChar *bitmapChar = GET_CHAR(charID);
             
-            if (kerning) 
+            if (kerning)
                 currentX += [bitmapChar kerningToChar:lastCharID];
             
+            SPImage *charImage = [bitmapChar createImage];
             charImage.x = currentX + bitmapChar.xOffset;
             charImage.y = bitmapChar.yOffset;
-
+            
             charImage.color = color;
             [currentLine addChild:charImage];
             
             currentX += bitmapChar.xAdvance;
 			lastCharID = charID;
             
-            if (currentX > containerWidth)        
+            if (currentX > maxWidth)
             {
-                // remove characters and add them again to next line
-                int numCharsToRemove = lastWhiteSpace == -1 ? 1 : i - lastWhiteSpace;
-                int removeIndex = currentLine.numChildren - numCharsToRemove;
-                
-                for (int i=0; i<numCharsToRemove; ++i)
-                    [currentLine removeChildAtIndex:removeIndex];
-                
-                if (currentLine.numChildren == 0)
-                    break;
-                
-                SPDisplayObject *lastChar = [currentLine childAtIndex:currentLine.numChildren-1];
-                currentX = lastChar.x + lastChar.width;
-                
-                i -= numCharsToRemove;
                 lineFull = YES;
+                if (multiline) 
+                {   
+                    // remove characters and add them again to next line
+                    int numCharsToRemove = lastWhiteSpace == -1 ? 1 : i - lastWhiteSpace;
+                    int removeIndex = currentLine.numChildren - numCharsToRemove;
+                    
+                    for (int i=0; i<numCharsToRemove; ++i)
+                        [currentLine removeChildAtIndex:removeIndex];
+                    
+                    if (currentLine.numChildren == 0)
+                        break;
+                    
+                    SPDisplayObject *lastChar = [currentLine childAtIndex:currentLine.numChildren-1];
+                    currentX = lastChar.x + lastChar.width;
+                    
+                    i -= numCharsToRemove;
+                }
             }
         }
         
-        if (lineFull || i == text.length - 1)
+        if (lineFull || i == text.length - 1) 
         {
-            float nextLineY = currentLine.y + mLineHeight;             
-            [lineContainer addChild:currentLine];                        
+            totalWidth = MAX([SPBitmapFont getLineWidth:currentLine] * scale, totalWidth);
+            totalHeight += (mLineHeight * scale);
             
-            if (nextLineY + mLineHeight <= containerHeight)
+            [lineContainer addChild:currentLine];
+            
+            if (totalHeight < maxHeight) 
             {
                 currentLine = [SPSprite sprite];
-                currentLine.y = nextLineY;            
+                currentLine.y = totalHeight;
+                
                 currentX = 0;
+                currentLineStartIdx = i + 1;
                 lastWhiteSpace = -1;
                 lastCharID = -1;
             }
-            else
+            else 
             {
                 break;
             }
         }
     }
     
-    // hAlign
-    if (hAlign != SPHAlignLeft)
+    if (autoSize == SPAutoSizeNone)
     {
-        for (SPSprite *line in lineContainer)
+        totalWidth = width;
+        totalHeight = height;
+    }
+    
+    // hAlign
+    if (autoSize != SPAutoSizeSingleLine && hAlign != SPHAlignLeft) 
+    {
+        for (SPSprite* line in lineContainer)  
         {
-            if (line.numChildren == 0) continue;
-            SPDisplayObject *lastChar = [line childAtIndex:line.numChildren-1];
-            float lineWidth = lastChar.x + lastChar.width;
-            float widthDiff = containerWidth - lineWidth;
+            float lineWidth = [SPBitmapFont getLineWidth:line];
+            float widthDiff = (totalWidth / scale) - lineWidth;
             line.x = (int) (hAlign == SPHAlignRight ? widthDiff : widthDiff / 2);
         }
     }
     
     SPSprite *outerContainer = [SPCompiledSprite sprite];
-    [outerContainer addChild:lineContainer];    
+    [outerContainer addChild:lineContainer];
     
-    if (vAlign != SPVAlignTop)
+    // vAlign is incompatible with autoSizing
+    if (autoSize == SPAutoSizeNone && vAlign != SPVAlignTop)
     {
         float contentHeight = lineContainer.numChildren * mLineHeight * scale;
-        float heightDiff = height - contentHeight;
+        float heightDiff = totalHeight - contentHeight;
         lineContainer.y = (int)(vAlign == SPVAlignBottom ? heightDiff : heightDiff / 2.0f);
     }
     
     if (border)
     {
-        SPQuad *topBorder = [SPQuad quadWithWidth:width height:1];
-        SPQuad *bottomBorder = [SPQuad quadWithWidth:width height:1];
-        SPQuad *leftBorder = [SPQuad quadWithWidth:1 height:height-2];
-        SPQuad *rightBorder = [SPQuad quadWithWidth:1 height:height-2];
+        SPQuad *topBorder = [SPQuad quadWithWidth:totalWidth height:1];
+        SPQuad *bottomBorder = [SPQuad quadWithWidth:totalWidth height:1];
+        SPQuad *leftBorder = [SPQuad quadWithWidth:1 height:totalHeight-2];
+        SPQuad *rightBorder = [SPQuad quadWithWidth:1 height:totalHeight-2];
         
         topBorder.color = bottomBorder.color = leftBorder.color = rightBorder.color = color;
-        bottomBorder.y = height - 1;
+        bottomBorder.y = totalHeight - 1;
         leftBorder.y = rightBorder.y = 1;
-        rightBorder.x = width - 1;
+        rightBorder.x = totalWidth - 1;
         
         [outerContainer addChild:topBorder];
         [outerContainer addChild:bottomBorder];
         [outerContainer addChild:leftBorder];
         [outerContainer addChild:rightBorder];        
-    }    
+    }
     
     return outerContainer;
 }

--- a/sparrow/src/Classes/SPTextField.h
+++ b/sparrow/src/Classes/SPTextField.h
@@ -38,6 +38,13 @@ typedef enum
     SPVAlignBottom
 } SPVAlign;
 
+typedef enum 
+{
+    SPAutoSizeNone = 0,
+    SPAutoSizeSingleLine,
+    SPAutoSizeMultiline
+} SPAutoSize;
+
 /** ------------------------------------------------------------------------------------------------
 
  An SPTextField displays text, either using standard iOS fonts or a custom bitmap font.
@@ -100,6 +107,10 @@ typedef enum
     SPQuad *mHitArea;
     SPQuad *mTextArea;
     SPDisplayObject *mContents;
+    
+    SPAutoSize mAutoSize;
+    float mAutoSizeMaxWidth;
+    float mAutoSizeMaxHeight;
 }
 
 /// ------------------
@@ -161,6 +172,15 @@ typedef enum
 
 /// The vertical alignment of the text.
 @property (nonatomic, assign) SPVAlign vAlign;
+
+/// The auto-size behavior of the text field.
+@property (nonatomic, assign) SPAutoSize autoSize;
+
+/// If autosizing is used, this is the max width of the text field. 0 == no max width.
+@property (nonatomic, assign) float autoSizeMaxWidth;
+
+/// If autosizing is used, this is the max height of the text field. 0 == no max height.
+@property (nonatomic, assign) float autoSizeMaxHeight;
 
 /// Allows displaying a border around the edges of the text field. Useful for visual debugging.
 @property (nonatomic, assign) BOOL border;


### PR DESCRIPTION
This makes it possible for SPTextFields to automatically resize themselves,
rather than relying on the user to specify a fixed width and height.

There are two auto-size modes: SPAutoSizeSingleLine (which lays out
text on a single line regardless of linebreaks); and SPAutoSizeMultiline.

SPTextField.autoSizeMaxWidth and autoSizeMaxHeight allow control over the bounds
of auto-sized text fields.

(This works with both rendered and composed text fields)
