### PR TITLE
Allow specification of fontName in the various registerBitmapFontFromFile: methods

### DIFF
--- a/sparrow/src/Classes/SPTextField.h
+++ b/sparrow/src/Classes/SPTextField.h
@@ -130,15 +130,26 @@ typedef enum
 /// @name Methods
 /// -------------
 
+/// Makes a bitmap font available at any text field, manually providing the texture and font name.
+/// 
+/// @return The name of the font that was passed to the method.
++ (NSString *)registerBitmapFontFromFile:(NSString *)path texture:(SPTexture *)texture name:(NSString *)fontName;
+
 /// Makes a bitmap font available at any text field, manually providing the texture.
 /// 
 /// @return The name of the font as defined in the font XML. 
-+ (NSString *)registerBitmapFontFromFile:(NSString*)path texture:(SPTexture *)texture;
++ (NSString *)registerBitmapFontFromFile:(NSString *)path texture:(SPTexture *)texture;
+
+/// Makes a bitmap font available at any text field, using the texture defined in the file,
+/// and manually providing the font name.
+/// 
+/// @return The name of the font that was passed to the method.
++ (NSString *)registerBitmapFontFromFile:(NSString *)path name:(NSString *)fontName;
 
 /// Makes a bitmap font available at any text field, using the texture defined in the file.
 /// 
 /// @return The name of the font as defined in the font XML. 
-+ (NSString *)registerBitmapFontFromFile:(NSString*)path;
++ (NSString *)registerBitmapFontFromFile:(NSString *)path;
 
 /// Releases the bitmap font.
 + (void)unregisterBitmapFont:(NSString *)name;

--- a/sparrow/src/Classes/SPTextField.m
+++ b/sparrow/src/Classes/SPTextField.m
@@ -309,21 +309,31 @@ static NSMutableDictionary *bitmapFonts = nil;
     return [[[SPTextField alloc] initWithText:text] autorelease];
 }
 
-+ (NSString *)registerBitmapFontFromFile:(NSString*)path texture:(SPTexture *)texture
++ (NSString *)registerBitmapFontFromFile:(NSString*)path texture:(SPTexture *)texture name:(NSString *)fontName
 {
     if (!bitmapFonts) bitmapFonts = [[NSMutableDictionary alloc] init];
     
     SPBitmapFont *bitmapFont = [[SPBitmapFont alloc] initWithContentsOfFile:path texture:texture];
-    NSString *fontName = bitmapFont.name;
+    if (!fontName) fontName = bitmapFont.name;
     [bitmapFonts setObject:bitmapFont forKey:fontName];
     [bitmapFont release];
     
     return fontName;
 }
 
++ (NSString *)registerBitmapFontFromFile:(NSString *)path texture:(SPTexture *)texture
+{
+    return [SPTextField registerBitmapFontFromFile:path texture:texture name:nil];
+}
+
++ (NSString *)registerBitmapFontFromFile:(NSString *)path name:(NSString *)fontName
+{
+    return [SPTextField registerBitmapFontFromFile:path texture:nil name:fontName];
+}
+
 + (NSString *)registerBitmapFontFromFile:(NSString *)path
 {
-    return [SPTextField registerBitmapFontFromFile:path texture:nil];
+    return [SPTextField registerBitmapFontFromFile:path texture:nil name:nil];
 }
 
 + (void)unregisterBitmapFont:(NSString *)name


### PR DESCRIPTION
This allows apps to use custom font naming schemes (for example, I might register font A as "DefaultFont" at some point in the app, and register a different font B as "DefaultFont" later on).

Also, this allows multiple versions of the same bitmap font to be registered without overwriting each other. (In bmGlyph, at least, the 'face' attribute that Sparrow uses as the font's registered name is always 'Helvetica', or whatever the font family name is. A game that loads a Helvetica20 and Helvetica40 will only end up will lose the first font when the second is loaded.)
