### PR TITLE
Assign specific values to SPTouchPhase constants

### DIFF
--- a/sparrow/src/Classes/SPTouch.h
+++ b/sparrow/src/Classes/SPTouch.h
@@ -17,7 +17,7 @@
 /// SPTouchPhase describes the phases in the life-cycle of a touch.
 typedef enum 
 {    
-    SPTouchPhaseBegan,      /// The finger just touched the screen.    
+    SPTouchPhaseBegan = 0,  /// The finger just touched the screen.    
     SPTouchPhaseMoved,      /// The finger moves around.    
     SPTouchPhaseStationary, /// The finger has not moved since the last frame.    
     SPTouchPhaseEnded,      /// The finger was lifted from the screen.    


### PR DESCRIPTION
This is super-basic - I'd like to use SPTouchPhase values to index an array, so just want to make sure their values are well-defined.
