### PR TITLE
Display object clipping

### DIFF
--- a/sparrow/src/Classes/SPDisplayObjectContainer.h
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.h
@@ -124,6 +124,8 @@
 @property (nonatomic, readonly) int numChildren;
 
 /// The object's clip rect (or nil if there's no clipping)
+/// *Note*: clip rects are axis aligned with the screen, so they
+/// will *not* be rotated or skewed if the DisplayObjectContainer is.
 @property (nonatomic, copy) SPRectangle *clipRect;
 
 

--- a/sparrow/src/Classes/SPDisplayObjectContainer.h
+++ b/sparrow/src/Classes/SPDisplayObjectContainer.h
@@ -63,6 +63,7 @@
 {
   @private
     NSMutableArray *mChildren;
+    SPRectangle *mClipRect;
 }
 
 /// -------------
@@ -111,12 +112,19 @@
 /// Dispatches an event on all children (recursively). The event must not bubble. */
 - (void)broadcastEvent:(SPEvent *)event;
 
+/// Returns the bounds of the container's clipRect in the given coordinate space
+/// (or nil if the container doesn't have a clipRect)
+- (SPRectangle *)clipBoundsInSpace:(SPDisplayObject *)targetCoordinateSpace;
+
 /// ----------------
 /// @name Properties
 /// ----------------
 
 /// The number of children of this container.
 @property (nonatomic, readonly) int numChildren;
+
+/// The object's clip rect (or nil if there's no clipping)
+@property (nonatomic, copy) SPRectangle *clipRect;
 
 
 @end

--- a/sparrow/src/Classes/SPRenderSupport.h
+++ b/sparrow/src/Classes/SPRenderSupport.h
@@ -13,6 +13,7 @@
 
 @class SPTexture;
 @class SPDisplayObject;
+@class SPRectangle;
 
 /** ------------------------------------------------------------------------------------------------
 
@@ -31,6 +32,8 @@
   @private
     uint mBoundTextureID;
     BOOL mPremultipliedAlpha;
+    NSMutableArray *mClipRectStack;
+    BOOL mScissorTestEnabled;
 }
 
 /// -------------
@@ -42,6 +45,13 @@
 
 /// Converts color and alpha into the format needed by OpenGL. Premultiplies alpha depending on state.
 - (uint)convertColor:(uint)color alpha:(float)alpha;
+
+/// Pushes a clipping rectangle to the stack, intersecting it with the last pushed clipRect.
+/// Returns the pushed rectangle.
+- (SPRectangle *)pushClipRect:(SPRectangle *)clipRect;
+
+/// Pops the last clipping rectangle that was pushed to the stack.
+- (void)popClipRect;
 
 /// Resets texture binding and alpha settings.
 - (void)reset;

--- a/sparrow/src/Classes/SPRenderSupport.m
+++ b/sparrow/src/Classes/SPRenderSupport.m
@@ -105,11 +105,13 @@
 
 - (SPRectangle *)pushClipRect:(SPRectangle *)clipRect
 {
-    // intersect with the last pushed clipRect
-    if (mClipRectStack != nil)
-        clipRect = [clipRect intersectionWithRectangle:[mClipRectStack lastObject]];
-    else
+    if (mClipRectStack == nil)
         mClipRectStack = [[NSMutableArray alloc] init];
+    else if (mClipRectStack.count > 0)
+    {
+        // intersect with the last pushed clipRect
+        clipRect = [clipRect intersectionWithRectangle:[mClipRectStack lastObject]];
+    }
     
     [mClipRectStack addObject:clipRect];
     [self updateClipping];

--- a/sparrow/src/Classes/SPRenderSupport.m
+++ b/sparrow/src/Classes/SPRenderSupport.m
@@ -80,8 +80,10 @@
 - (void)updateClipping
 {
     SPRectangle *clip = [mClipRectStack lastObject];
-    if (clip != nil) {
-        if (!mScissorTestEnabled) {
+    if (clip != nil)
+    {
+        if (!mScissorTestEnabled)
+        {
             glEnable(GL_SCISSOR_TEST);
             mScissorTestEnabled = YES;
         }
@@ -93,7 +95,9 @@
                   clip.width*scaleFactor,
                   clip.height*scaleFactor);
         
-    } else if (mScissorTestEnabled) {
+    }
+    else if (mScissorTestEnabled)
+    {
         glDisable(GL_SCISSOR_TEST);
         mScissorTestEnabled = NO;
     }
@@ -102,11 +106,10 @@
 - (SPRectangle *)pushClipRect:(SPRectangle *)clipRect
 {
     // intersect with the last pushed clipRect
-    if (mClipRectStack != nil) {
+    if (mClipRectStack != nil)
         clipRect = [clipRect intersectionWithRectangle:[mClipRectStack lastObject]];
-    } else {
+    else
         mClipRectStack = [[NSMutableArray alloc] init];
-    }
     
     [mClipRectStack addObject:clipRect];
     [self updateClipping];

--- a/sparrow/src/Classes/SPRendering.m
+++ b/sparrow/src/Classes/SPRendering.m
@@ -46,6 +46,16 @@
 {    
     float alpha = self.alpha;
     
+    if (mClipRect != nil) {
+        SPRectangle *clip = [support pushClipRect:[self clipBoundsInSpace:self.stage]];
+        // Don't bother rendering our children if our clipping bounds
+        // are empty
+        if (clip.isEmpty) {
+            [support popClipRect];
+            return;
+        }
+    }
+    
     for (SPDisplayObject *child in mChildren)
     {
         float childAlpha = child.alpha;
@@ -61,6 +71,10 @@
             
             glPopMatrix();        
         }
+    }
+    
+    if (mClipRect != nil) {
+        [support popClipRect];
     }
 }
 

--- a/sparrow/src/Classes/SPRendering.m
+++ b/sparrow/src/Classes/SPRendering.m
@@ -44,17 +44,19 @@
 
 - (void)render:(SPRenderSupport *)support
 {    
-    float alpha = self.alpha;
-    
-    if (mClipRect != nil) {
+    if (mClipRect != nil)
+    {
         SPRectangle *clip = [support pushClipRect:[self clipBoundsInSpace:self.stage]];
         // Don't bother rendering our children if our clipping bounds
         // are empty
-        if (clip.isEmpty) {
+        if (clip.isEmpty)
+        {
             [support popClipRect];
             return;
         }
     }
+    
+    float alpha = self.alpha;
     
     for (SPDisplayObject *child in mChildren)
     {
@@ -73,9 +75,8 @@
         }
     }
     
-    if (mClipRect != nil) {
+    if (mClipRect != nil)
         [support popClipRect];
-    }
 }
 
 @end


### PR DESCRIPTION
Hi Daniel,

I've added clipRect support to SPDisplayObjectContainer. It's partly based on the work that Shilo did with his SHClippedSprite class (https://gist.github.com/1346513), but since it's properly integrated with Sparrow, it's more efficient. There's no API or performance impact for users that don't use clipRects. 

For those that do, using a clipRect is as simple as setting the clipRect property on a SPDisplayObjectContainer. The performance impact for clipping should be negligible.

It's pretty basic - it just uses GL_SCISSOR_TEST, which means that it doesn't support non-axis-aligned clipRects, so clipped sprites that are rotated won't have their rotation applied to the clipping. (The docs make a note of this.)
