### PR TITLE
Thread-safe SPPool

### DIFF
--- a/sparrow/src/Classes/SPMatrix.m
+++ b/sparrow/src/Classes/SPMatrix.m
@@ -158,11 +158,6 @@ static void setValues(SPMatrix *matrix, float a, float b, float c, float d, floa
 
 #pragma mark SPPoolObject
 
-+ (SPPoolInfo *)poolInfo
-{
-    static SPPoolInfo *poolInfo = nil;
-    if (!poolInfo) poolInfo = [[SPPoolInfo alloc] init];
-    return poolInfo;
-}
+SP_IMPLEMENT_MEMORY_POOL();
 
 @end

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -168,11 +168,6 @@
 
 #pragma mark SPPoolObject
 
-+ (SPPoolInfo *)poolInfo
-{
-    static SPPoolInfo *poolInfo = nil;
-    if (!poolInfo) poolInfo = [[SPPoolInfo alloc] init];
-    return poolInfo;
-}
+SP_IMPLEMENT_MEMORY_POOL();
 
 @end

--- a/sparrow/src/Classes/SPPoolObject.h
+++ b/sparrow/src/Classes/SPPoolObject.h
@@ -23,6 +23,15 @@
 
 @end
 
+#define SP_IMPLEMENT_MEMORY_POOL() \
+    + (SPPoolInfo *)poolInfo \
+    {   \
+        static dispatch_once_t once; \
+        static SPPoolInfo *poolInfo = nil;  \
+        dispatch_once(&once, ^{ poolInfo = [[SPPoolInfo alloc] init]; }); \
+        return poolInfo;    \
+    }   \
+
 /** ------------------------------------------------------------------------------------------------
  
  The SPPoolObject class is an alternative to the base class `NSObject` that manages a pool of 
@@ -36,15 +45,10 @@
  Sparrow uses this class for `SPPoint`, `SPRectangle` and `SPMatrix`, as they are created very often 
  as helper objects.
  
- To use memory pooling for another class, you just have to inherit from SPPoolObject and implement
- the following method:
+ To use memory pooling for another class, you just have to inherit from SPPoolObject and put
+ the following macro somewhere in your implementation:
  
- 	+ (SPPoolInfo *)poolInfo
- 	{
- 	    static SPPoolInfo *poolInfo = nil;
- 	    if (!poolInfo) poolInfo = [[SPPoolInfo alloc] init];
- 	    return poolInfo;
- 	}
+    SP_IMPLEMENT_MEMORY_POOL();
  
  ------------------------------------------------------------------------------------------------- */
 
@@ -54,7 +58,7 @@
 {
   @private
     SPPoolObject *mPoolPredecessor;
-    uint mRetainCount;
+    volatile uint32_t mRetainCount;
 }
 
 /// The pool info structure needed to access the pool. Needs to be implemented in any inheriting class.

--- a/sparrow/src/Classes/SPPoolObject.m
+++ b/sparrow/src/Classes/SPPoolObject.m
@@ -11,14 +11,9 @@
 
 #import "SPPoolObject.h"
 #import <malloc/malloc.h>
+#import <libkern/OSAtomic.h>
 
-#define COMPLAIN_MISSING_IMP @"Class %@ needs this code:\n\
-+ (SPPoolInfo *) poolInfo\n\
-{\n\
-  static SPPoolInfo *poolInfo = nil;\n\
-  if (!poolInfo) poolInfo = [[SPPoolInfo alloc] init];\n\
-  return poolInfo;\n\
-}"
+#define COMPLAIN_MISSING_IMP @"Class %@ needs this code:\nSP_IMPLEMENT_MEMORY_POOL();"
 
 @implementation SPPoolInfo
 // empty
@@ -30,59 +25,69 @@
 
 + (id)allocWithZone:(NSZone *)zone
 {
+    BOOL recycled = NO;
+    SPPoolObject *object = nil;
     SPPoolInfo *poolInfo = [self poolInfo];
-    if (!poolInfo->poolClass) // first allocation
+    @synchronized(poolInfo) 
     {
-        poolInfo->poolClass = self;
-        poolInfo->lastElement = NULL;
-    }
-    else 
-    {
-        if (poolInfo->poolClass != self)
-            [NSException raise:NSGenericException format:COMPLAIN_MISSING_IMP, self];
+        if (!poolInfo->poolClass) // first allocation
+        {
+            poolInfo->poolClass = self;
+            poolInfo->lastElement = NULL;
+        }
+        else 
+        {
+            if (poolInfo->poolClass != self)
+                [NSException raise:NSGenericException format:COMPLAIN_MISSING_IMP, self];
+        }
+        
+        if (!poolInfo->lastElement) 
+        {
+            // pool is empty -> allocate
+            object = NSAllocateObject(self, 0, NULL);
+        }
+        else 
+        {
+            // recycle element, update poolInfo
+            SPPoolObject *object = poolInfo->lastElement;
+            poolInfo->lastElement = object->mPoolPredecessor;
+            recycled = YES;
+        }
     }
     
-    if (!poolInfo->lastElement) 
+    if (recycled) 
     {
-        // pool is empty -> allocate
-        SPPoolObject *object = NSAllocateObject(self, 0, NULL);
-        object->mRetainCount = 1;
-        return object;
-    }
-    else 
-    {
-        // recycle element, update poolInfo
-        SPPoolObject *object = poolInfo->lastElement;
-        poolInfo->lastElement = object->mPoolPredecessor;
-
         // zero out memory. (do not overwrite isa & mPoolPredecessor, thus the offset)
         unsigned int sizeOfFields = sizeof(Class) + sizeof(SPPoolObject *);
         memset((char*)(id)object + sizeOfFields, 0, malloc_size(object) - sizeOfFields);
-        object->mRetainCount = 1;
         return object;
     }
+    
+    object->mRetainCount = 1;
+    return object;
 }
 
-- (uint)retainCount
+- (uint32_t)retainCount
 {
     return mRetainCount;
 }
 
 - (id)retain
 {
-    ++mRetainCount;
+    OSAtomicIncrement32Barrier((int32_t*) &mRetainCount);
     return self;
 }
 
 - (oneway void)release
-{
-    --mRetainCount;
-    
-    if (!mRetainCount)
+{   
+    if (!OSAtomicDecrement32Barrier((int32_t*) &mRetainCount))
     {
         SPPoolInfo *poolInfo = [isa poolInfo];
-        self->mPoolPredecessor = poolInfo->lastElement;
-        poolInfo->lastElement = self;
+        @synchronized(poolInfo) 
+        {
+            self->mPoolPredecessor = poolInfo->lastElement;
+            poolInfo->lastElement = self;
+        }
     }
 }
 
@@ -95,18 +100,21 @@
 
 + (int)purgePool
 {
-    SPPoolInfo *poolInfo = [self poolInfo];    
-    SPPoolObject *lastElement;    
-    
-    int count=0;
-    while ((lastElement = poolInfo->lastElement))
+    SPPoolInfo *poolInfo = [self poolInfo];
+    @synchronized(poolInfo)
     {
-        ++count;        
-        poolInfo->lastElement = lastElement->mPoolPredecessor;
-        [lastElement purge];
+        SPPoolObject *lastElement;    
+        
+        int count=0;
+        while ((lastElement = poolInfo->lastElement))
+        {
+            ++count;        
+            poolInfo->lastElement = lastElement->mPoolPredecessor;
+            [lastElement purge];
+        }
+        
+        return count;
     }
-    
-    return count;
 }
 
 + (SPPoolInfo *)poolInfo

--- a/sparrow/src/Classes/SPPoolObject.m
+++ b/sparrow/src/Classes/SPPoolObject.m
@@ -49,7 +49,7 @@
         else 
         {
             // recycle element, update poolInfo
-            SPPoolObject *object = poolInfo->lastElement;
+            object = poolInfo->lastElement;
             poolInfo->lastElement = object->mPoolPredecessor;
             recycled = YES;
         }
@@ -60,7 +60,6 @@
         // zero out memory. (do not overwrite isa & mPoolPredecessor, thus the offset)
         unsigned int sizeOfFields = sizeof(Class) + sizeof(SPPoolObject *);
         memset((char*)(id)object + sizeOfFields, 0, malloc_size(object) - sizeOfFields);
-        return object;
     }
     
     object->mRetainCount = 1;

--- a/sparrow/src/Classes/SPRectangle.m
+++ b/sparrow/src/Classes/SPRectangle.m
@@ -163,11 +163,6 @@
 
 #pragma mark SPPoolObject
 
-+ (SPPoolInfo *)poolInfo
-{
-    static SPPoolInfo *poolInfo = nil;
-    if (!poolInfo) poolInfo = [[SPPoolInfo alloc] init];
-    return poolInfo;
-}
+SP_IMPLEMENT_MEMORY_POOL();
 
 @end


### PR DESCRIPTION
Hey Daniel,

The current implementation of SPPool is not thread-safe, which I just learned the hard way after spending a  long day tracking down baffling memory errors. My game isn't heavily multithreaded, but it does load assets on another thread, as I suspect most games do - and some of that asset loading involves points, matrices, and rectangles. (Also, the game will eventually need a network thread or two - more places for potential memory blowups).

I tried to be as efficient as possible in this modification (using @synchronized only when absolutely necessary - i.e. when performing an operation on an SPPoolInfo\* itself, not when modifying an object's retain count).

Since the - (SPPoolInfo *)poolInfo implementation also changed, I created a macro  - SP_IMPLEMENT_MEMORY_POOL() - that classes should use, rather than copy-pasting the implementation. (This should also help future-proof classes against more changes down the road).
