### PR TITLE
Object pooling is disabled by default.

### DIFF
--- a/sparrow/src/Classes/SPPoolObject.m
+++ b/sparrow/src/Classes/SPPoolObject.m
@@ -12,19 +12,13 @@
 #import "SPPoolObject.h"
 #import <malloc/malloc.h>
 
-#define COMPLAIN_MISSING_IMP @"Class %@ needs this code:\n\
-+ (SPPoolInfo *) poolInfo\n\
-{\n\
-  static SPPoolInfo *poolInfo = nil;\n\
-  if (!poolInfo) poolInfo = [[SPPoolInfo alloc] init];\n\
-  return poolInfo;\n\
-}"
+#define COMPLAIN_MISSING_IMP @"Class %@ needs this code:\nSP_IMPLEMENT_MEMORY_POOL();"
 
 @implementation SPPoolInfo
 // empty
 @end
 
-#ifndef DISABLE_MEMORY_POOLING
+#ifdef SP_ENABLE_MEMORY_POOLING
 
 @implementation SPPoolObject
 

--- a/sparrow/src/UnitTests/SPPoolObjectTest.m
+++ b/sparrow/src/UnitTests/SPPoolObjectTest.m
@@ -28,7 +28,7 @@
 
 - (void)testObjectPooling
 {
-    #ifndef DISABLE_MEMORY_POOLING
+    #ifdef SP_ENABLE_MEMORY_POOLING
     
     [SPPoint purgePool]; // clean existing pool
     


### PR DESCRIPTION
This disables SPPoolObject by default; it can be enabled with SP_ENABLE_MEMORY_POOLING.

I also updated the documentation of SPPoolObject to explain the thread-safety issues.
