### PR TITLE
Whoops - this is deprecated starting in iOS 6, not iOS 5

### DIFF
--- a/sparrow/src/Classes/SPTextField.m
+++ b/sparrow/src/Classes/SPTextField.m
@@ -294,7 +294,7 @@ static NSMutableDictionary *bitmapFonts = nil;
     float height = mHitArea.height;    
     float fontSize = mFontSize == SP_NATIVE_FONT_SIZE ? SP_DEFAULT_FONT_SIZE : mFontSize;
     
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 50000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 60000
     NSLineBreakMode lbm = NSLineBreakByTruncatingTail;
 #else
     UILineBreakMode lbm = UILineBreakModeTailTruncation;


### PR DESCRIPTION
Fixes my previous commit. I'd incorrectly thought that NSLineBreakMode was introduced in iOS 5, but it's actually in iOS 6
