### PR TITLE
Added rotation with origin point

### DIFF
--- a/sparrow/src/Classes/SPPoint.h
+++ b/sparrow/src/Classes/SPPoint.h
@@ -56,6 +56,9 @@
 /// Rotates the point by the given angle (in radians, CCW) and returns the resulting point.
 - (SPPoint *)rotateBy:(float)angle;
 
+/// Rotates the point by the given angle (in rad), using an originX and Y (like pivot point) and returns the resulting point.
+- (SPPoint *)rotateBy:(float)angle originX:(float)xc originY:(float)yc;
+
 /// Returns a point that has the same direction but a length of one.
 - (SPPoint *)normalize;
 

--- a/sparrow/src/Classes/SPPoint.m
+++ b/sparrow/src/Classes/SPPoint.m
@@ -95,6 +95,20 @@
     return [result autorelease];
 }
 
+- (SPPoint *)rotateBy:(float)angle originX:(float)xc originY:(float)yc {
+    float xt = mX - xc;
+    float yt = mY - yc;
+    
+    float c = cosf(angle);
+    float s = sinf(angle);
+    
+    float xr = (xt * c - yt * s) + xc;
+    float yr = (xt * s + yt * c) + yc;
+    
+    SPPoint *result = [[SPPoint alloc] initWithX:xr y:yr];
+    return [result autorelease];
+}
+
 - (SPPoint *)normalize
 {
     if (mX == 0 && mY == 0)


### PR DESCRIPTION
This is a very small change; I just added this function
- (SPPoint *)rotateBy:(float)angle originX:(float)xc originY:(float)yc;

which rotates the SPPoint with a given origin point - kind of like a pivot point for rotation.

I am also working on a rotated bounds method but that needs much polishing and testing.

First commit!: P
